### PR TITLE
Improve submission handling and add Arabic translation

### DIFF
--- a/app script.gs
+++ b/app script.gs
@@ -23,11 +23,15 @@ function doPost(e) {
       ]);
     });
 
-    return ContentService.createTextOutput(JSON.stringify({ status: "success" }))
-                         .setMimeType(ContentService.MimeType.JSON);
-  } catch (err) {
-    return ContentService.createTextOutput(JSON.stringify({ status: "error", message: err.message }))
-                         .setMimeType(ContentService.MimeType.JSON);
+      return ContentService
+        .createTextOutput(JSON.stringify({ status: "success" }))
+        .setMimeType(ContentService.MimeType.JSON)
+        .setHeader("Access-Control-Allow-Origin", "*");
+    } catch (err) {
+      return ContentService
+        .createTextOutput(JSON.stringify({ status: "error", message: err.message }))
+        .setMimeType(ContentService.MimeType.JSON)
+        .setHeader("Access-Control-Allow-Origin", "*");
+    }
   }
-}
 

--- a/index.html
+++ b/index.html
@@ -15,10 +15,10 @@
 <body>
   <!-- Loading Overlay -->
   <div id="loadingOverlay" class="loading-overlay">
-    <div class="loading-spinner">
-      <div class="spinner"></div>
-      <p>Loading inventory data...</p>
-    </div>
+      <div class="loading-spinner">
+        <div class="spinner"></div>
+        <p data-i18n="loadingData">Loading inventory data...</p>
+      </div>
   </div>
 
   <!-- Main Container -->
@@ -28,13 +28,17 @@
       <div class="header-content">
         <div class="logo-section">
           <img src="https://i.imgur.com/J2WFvE2.png" alt="Company Logo" class="logo">
-          <div class="header-text">
-            <h1>Stock In Trade</h1>
-            <p>Inventory Management System</p>
-          </div>
+            <div class="header-text">
+              <h1 data-i18n="title">Stock In Trade</h1>
+              <p data-i18n="subtitle">Inventory Management System</p>
+            </div>
         </div>
         <div class="header-actions">
-          <!-- Reset button moved to submit section -->
+            <select id="languageSwitcher" class="language-switcher">
+              <option value="en">English</option>
+              <option value="ar">العربية</option>
+            </select>
+            <!-- Reset button moved to submit section -->
         </div>
       </div>
     </header>
@@ -45,26 +49,26 @@
         <div class="progress-fill" id="progressFill"></div>
       </div>
       <div class="progress-steps">
-        <div class="step active" data-step="1">
-          <i class="fas fa-calendar-alt"></i>
-          <span>Week</span>
-        </div>
-        <div class="step" data-step="2">
-          <i class="fas fa-stream"></i>
-          <span>Channel</span>
-        </div>
-        <div class="step" data-step="3">
-          <i class="fas fa-user-tie"></i>
-          <span>Salesman</span>
-        </div>
-        <div class="step" data-step="4">
-          <i class="fas fa-building"></i>
-          <span>Customer</span>
-        </div>
-        <div class="step" data-step="5">
-          <i class="fas fa-boxes"></i>
-          <span>Products</span>
-        </div>
+          <div class="step active" data-step="1">
+            <i class="fas fa-calendar-alt"></i>
+            <span data-i18n="week">Week</span>
+          </div>
+          <div class="step" data-step="2">
+            <i class="fas fa-stream"></i>
+            <span data-i18n="channel">Channel</span>
+          </div>
+          <div class="step" data-step="3">
+            <i class="fas fa-user-tie"></i>
+            <span data-i18n="salesman">Salesman</span>
+          </div>
+          <div class="step" data-step="4">
+            <i class="fas fa-building"></i>
+            <span data-i18n="customer">Customer</span>
+          </div>
+          <div class="step" data-step="5">
+            <i class="fas fa-boxes"></i>
+            <span data-i18n="products">Products</span>
+          </div>
       </div>
     </div>
 
@@ -72,24 +76,24 @@
     <main class="main-content">
       <div class="form-container">
         <!-- Form Section -->
-        <section class="form-section">
-          <h2>Order Details</h2>
+          <section class="form-section">
+            <h2 data-i18n="orderDetails">Order Details</h2>
           
           <div class="form-grid">
             <!-- Week Selection -->
             <div class="form-group">
               <label for="week" class="form-label">
                 <i class="fas fa-calendar-alt"></i>
-                Select Week
+                <span data-i18n="selectWeek">Select Week</span>
                 <span class="required">*</span>
               </label>
               <div class="select-wrapper">
                 <select id="week" class="form-select" required aria-describedby="week-error">
-                  <option value="">-- Select Week --</option>
-                  <option value="Week 1">Week 1</option>
-                  <option value="Week 2">Week 2</option>
-                  <option value="Week 3">Week 3</option>
-                  <option value="Week 4">Week 4</option>
+                  <option value="" data-i18n="weekPlaceholder">-- Select Week --</option>
+                  <option value="Week 1" data-i18n="week1">Week 1</option>
+                  <option value="Week 2" data-i18n="week2">Week 2</option>
+                  <option value="Week 3" data-i18n="week3">Week 3</option>
+                  <option value="Week 4" data-i18n="week4">Week 4</option>
                 </select>
                 <i class="fas fa-chevron-down select-icon"></i>
               </div>
@@ -100,12 +104,12 @@
             <div class="form-group">
               <label for="channel" class="form-label">
                 <i class="fas fa-stream"></i>
-                Select Channel
+                <span data-i18n="selectChannel">Select Channel</span>
                 <span class="required">*</span>
               </label>
               <div class="select-wrapper">
                 <select id="channel" class="form-select" required aria-describedby="channel-error">
-                  <option value="">-- Select Channel --</option>
+                  <option value="" data-i18n="channelPlaceholder">-- Select Channel --</option>
                 </select>
                 <i class="fas fa-chevron-down select-icon"></i>
                 <div class="loading-indicator" id="channel-loading">
@@ -119,12 +123,12 @@
             <div class="form-group">
               <label for="salesman" class="form-label">
                 <i class="fas fa-user-tie"></i>
-                Select Salesman
+                <span data-i18n="selectSalesman">Select Salesman</span>
                 <span class="required">*</span>
               </label>
               <div class="select-wrapper">
                 <select id="salesman" class="form-select" required aria-describedby="salesman-error">
-                  <option value="">-- Select Salesman --</option>
+                  <option value="" data-i18n="salesmanPlaceholder">-- Select Salesman --</option>
                 </select>
                 <i class="fas fa-chevron-down select-icon"></i>
                 <div class="loading-indicator" id="salesman-loading">
@@ -138,12 +142,12 @@
             <div class="form-group">
               <label for="customer" class="form-label">
                 <i class="fas fa-building"></i>
-                Select Customer
+                <span data-i18n="selectCustomer">Select Customer</span>
                 <span class="required">*</span>
               </label>
               <div class="select-wrapper">
                 <select id="customer" class="form-select" required aria-describedby="customer-error">
-                  <option value="">-- Select Customer --</option>
+                  <option value="" data-i18n="customerPlaceholder">-- Select Customer --</option>
                 </select>
                 <i class="fas fa-chevron-down select-icon"></i>
                 <div class="loading-indicator" id="customer-loading">
@@ -157,22 +161,22 @@
 
         <!-- Products Section -->
         <section class="products-section">
-          <div class="section-header">
-            <h2>
-              <i class="fas fa-boxes"></i>
-              Product Inventory
-            </h2>
-            <div class="section-actions">
-              <button class="btn btn-outline" onclick="expandAll()" aria-label="Expand all categories">
-                <i class="fas fa-expand-alt"></i>
-                Expand All
-              </button>
-              <button class="btn btn-outline" onclick="collapseAll()" aria-label="Collapse all categories">
-                <i class="fas fa-compress-alt"></i>
-                Collapse All
-              </button>
+            <div class="section-header">
+              <h2>
+                <i class="fas fa-boxes"></i>
+                <span data-i18n="productInventory">Product Inventory</span>
+              </h2>
+              <div class="section-actions">
+                <button class="btn btn-outline" onclick="expandAll()" aria-label="Expand all categories">
+                  <i class="fas fa-expand-alt"></i>
+                  <span data-i18n="expandAll">Expand All</span>
+                </button>
+                <button class="btn btn-outline" onclick="collapseAll()" aria-label="Collapse all categories">
+                  <i class="fas fa-compress-alt"></i>
+                  <span data-i18n="collapseAll">Collapse All</span>
+                </button>
+              </div>
             </div>
-          </div>
           
           <div id="products" class="products-container">
             <!-- Products will be loaded here -->
@@ -187,47 +191,47 @@
         </section>
 
         <!-- Summary Section -->
-        <section class="summary-section" id="summarySection" style="display: none;">
-          <h3>Order Summary</h3>
-          <div class="summary-stats">
-            <div class="stat-card">
-              <i class="fas fa-boxes"></i>
-              <div>
-                <span class="stat-value" id="totalProducts">0</span>
-                <span class="stat-label">Products</span>
+          <section class="summary-section" id="summarySection" style="display: none;">
+            <h3 data-i18n="orderSummary">Order Summary</h3>
+            <div class="summary-stats">
+              <div class="stat-card">
+                <i class="fas fa-boxes"></i>
+                <div>
+                  <span class="stat-value" id="totalProducts">0</span>
+                  <span class="stat-label" data-i18n="productsStat">Products</span>
+                </div>
+              </div>
+              <div class="stat-card">
+                <i class="fas fa-cube"></i>
+                <div>
+                  <span class="stat-value" id="totalQuantity">0</span>
+                  <span class="stat-label" data-i18n="totalQty">Total Qty</span>
+                </div>
+              </div>
+              <div class="stat-card">
+                <i class="fas fa-chart-line"></i>
+                <div>
+                  <span class="stat-value" id="totalSellout">0</span>
+                  <span class="stat-label" data-i18n="selloutQty">Sellout Qty</span>
+                </div>
               </div>
             </div>
-            <div class="stat-card">
-              <i class="fas fa-cube"></i>
-              <div>
-                <span class="stat-value" id="totalQuantity">0</span>
-                <span class="stat-label">Total Qty</span>
-              </div>
-            </div>
-            <div class="stat-card">
-              <i class="fas fa-chart-line"></i>
-              <div>
-                <span class="stat-value" id="totalSellout">0</span>
-                <span class="stat-label">Sellout Qty</span>
-              </div>
-            </div>
-          </div>
-        </section>
+          </section>
 
         <!-- Submit Section -->
         <section class="submit-section">
           <div class="submit-actions">
             <button class="btn btn-primary" onclick="submitForm()" id="submitBtn" disabled>
               <i class="fas fa-paper-plane"></i>
-              Submit Order
+              <span data-i18n="submitOrder">Submit Order</span>
             </button>
             <button class="btn btn-secondary" onclick="previewOrder()" id="previewBtn" disabled>
               <i class="fas fa-eye"></i>
-              Preview
+              <span data-i18n="preview">Preview</span>
             </button>
             <button class="btn btn-outline" onclick="resetForm()" aria-label="Reset form">
               <i class="fas fa-refresh"></i>
-              Reset
+              <span data-i18n="reset">Reset</span>
             </button>
           </div>
         </section>
@@ -241,48 +245,49 @@
   <!-- Confirmation Modal -->
   <div class="modal-overlay" id="confirmationModal">
     <div class="modal">
-      <div class="modal-header">
-        <h3>Confirm Submission</h3>
-        <button class="modal-close" onclick="closeModal()" aria-label="Close modal">
-          <i class="fas fa-times"></i>
-        </button>
-      </div>
-      <div class="modal-body">
-        <p>Are you sure you want to submit this order?</p>
-        <div class="modal-summary" id="modalSummary"></div>
-      </div>
-      <div class="modal-actions">
-        <button class="btn btn-secondary" onclick="closeModal()">Cancel</button>
-        <button class="btn btn-primary" onclick="confirmSubmit()">
-          <i class="fas fa-check"></i>
-          Confirm Submit
-        </button>
+        <div class="modal-header">
+          <h3 data-i18n="confirmSubmission">Confirm Submission</h3>
+          <button class="modal-close" onclick="closeModal()" aria-label="Close modal">
+            <i class="fas fa-times"></i>
+          </button>
+        </div>
+        <div class="modal-body">
+          <p data-i18n="confirmQuestion">Are you sure you want to submit this order?</p>
+          <div class="modal-summary" id="modalSummary"></div>
+        </div>
+        <div class="modal-actions">
+          <button class="btn btn-secondary" onclick="closeModal()" data-i18n="cancel">Cancel</button>
+          <button class="btn btn-primary" onclick="confirmSubmit()">
+            <i class="fas fa-check"></i>
+            <span data-i18n="confirmSubmit">Confirm Submit</span>
+          </button>
+        </div>
       </div>
     </div>
-  </div>
 
   <!-- Preview Modal -->
   <div class="modal-overlay" id="previewModal">
     <div class="modal modal-large">
-      <div class="modal-header">
-        <h3>Order Preview</h3>
-        <button class="modal-close" onclick="closePreview()" aria-label="Close preview">
-          <i class="fas fa-times"></i>
-        </button>
-      </div>
+        <div class="modal-header">
+          <h3 data-i18n="orderPreview">Order Preview</h3>
+          <button class="modal-close" onclick="closePreview()" aria-label="Close preview">
+            <i class="fas fa-times"></i>
+          </button>
+        </div>
       <div class="modal-body">
         <div id="previewContent"></div>
       </div>
-      <div class="modal-actions">
-        <button class="btn btn-secondary" onclick="closePreview()">Close</button>
-        <button class="btn btn-primary" onclick="submitFromPreview()">
-          <i class="fas fa-paper-plane"></i>
-          Submit Order
-        </button>
+        <div class="modal-actions">
+          <button class="btn btn-secondary" onclick="closePreview()" data-i18n="close">Close</button>
+          <button class="btn btn-primary" onclick="submitFromPreview()">
+            <i class="fas fa-paper-plane"></i>
+            <span data-i18n="submitOrder">Submit Order</span>
+          </button>
+        </div>
       </div>
     </div>
-  </div>
 
-  <script src="script.js"></script>
-</body>
-</html>
+    <script src="https://cdn.jsdelivr.net/npm/i18next@23.4.6/i18next.min.js"></script>
+    <script src="script.js"></script>
+  </body>
+  </html>

--- a/script.js
+++ b/script.js
@@ -27,8 +27,184 @@ const elements = {
   previewBtn: document.getElementById('previewBtn'),
   toastContainer: document.getElementById('toastContainer'),
   confirmationModal: document.getElementById('confirmationModal'),
-  previewModal: document.getElementById('previewModal')
+  previewModal: document.getElementById('previewModal'),
+  languageSwitcher: document.getElementById('languageSwitcher')
 };
+
+// Translation resources
+const resources = {
+  en: {
+    translation: {
+      title: "Stock In Trade",
+      subtitle: "Inventory Management System",
+      week: "Week",
+      channel: "Channel",
+      salesman: "Salesman",
+      customer: "Customer",
+      products: "Products",
+      orderDetails: "Order Details",
+      selectWeek: "Select Week",
+      selectChannel: "Select Channel",
+      selectSalesman: "Select Salesman",
+      selectCustomer: "Select Customer",
+      weekPlaceholder: "-- Select Week --",
+      week1: "Week 1",
+      week2: "Week 2",
+      week3: "Week 3",
+      week4: "Week 4",
+      channelPlaceholder: "-- Select Channel --",
+      salesmanPlaceholder: "-- Select Salesman --",
+      customerPlaceholder: "-- Select Customer --",
+      productInventory: "Product Inventory",
+      expandAll: "Expand All",
+      collapseAll: "Collapse All",
+      orderSummary: "Order Summary",
+      productsStat: "Products",
+      totalQty: "Total Qty",
+      selloutQty: "Sellout Qty",
+      submitOrder: "Submit Order",
+      preview: "Preview",
+      reset: "Reset",
+      confirmSubmission: "Confirm Submission",
+      confirmQuestion: "Are you sure you want to submit this order?",
+      cancel: "Cancel",
+      confirmSubmit: "Confirm Submit",
+      orderPreview: "Order Preview",
+      close: "Close",
+      appLoaded: "Application loaded successfully",
+      validationError: "Please complete all required fields",
+      validationTitle: "Validation Error",
+      noProducts: "Please enter at least one product quantity or sellout quantity",
+      noProductsTitle: "No Products",
+      noProductsPreview: "No products selected for preview",
+      submitSuccess: "Order submitted successfully!",
+      success: "Success",
+      submitFailed: "Submission failed",
+      submissionError: "Submission Error",
+      initError: "Failed to initialize application. Please refresh the page.",
+      initErrorTitle: "Initialization Error",
+      formReset: "Form reset successfully",
+      resetConfirm: "Are you sure you want to reset the form? All data will be lost.",
+      submitting: "Submitting...",
+      loadingData: "Loading inventory data...",
+      orderDetailsHeader: "Order Details",
+      weekLabel: "Week:",
+      channelLabel: "Channel:",
+      salesmanLabel: "Salesman:",
+      customerLabel: "Customer:",
+      productCol: "Product",
+      quantityCol: "Quantity",
+      selloutCol: "Sellout",
+      dataRestored: "Form data restored successfully",
+      restoreConfirm: "Found saved form data. Would you like to restore it?",
+      loadingWarning: "Google Sheets loading slowly. Using cached data if available.",
+      usingCachedData: "Using cached data",
+      loadingWarningTitle: "Loading Warning",
+      loadingError: "Failed to load product data. Please refresh the page.",
+      loadingErrorTitle: "Loading Error",
+      failedProducts: "Failed to load products. Please refresh the page.",
+      retry: "Retry"
+    }
+  },
+  ar: {
+    translation: {
+      title: "المخزون التجاري",
+      subtitle: "نظام إدارة المخزون",
+      week: "الأسبوع",
+      channel: "القناة",
+      salesman: "مندوب المبيعات",
+      customer: "العميل",
+      products: "المنتجات",
+      orderDetails: "تفاصيل الطلب",
+      selectWeek: "اختر الأسبوع",
+      selectChannel: "اختر القناة",
+      selectSalesman: "اختر مندوب المبيعات",
+      selectCustomer: "اختر العميل",
+      weekPlaceholder: "-- اختر الأسبوع --",
+      week1: "الأسبوع 1",
+      week2: "الأسبوع 2",
+      week3: "الأسبوع 3",
+      week4: "الأسبوع 4",
+      channelPlaceholder: "-- اختر القناة --",
+      salesmanPlaceholder: "-- اختر مندوب المبيعات --",
+      customerPlaceholder: "-- اختر العميل --",
+      productInventory: "جرد المنتجات",
+      expandAll: "توسيع الكل",
+      collapseAll: "طي الكل",
+      orderSummary: "ملخص الطلب",
+      productsStat: "المنتجات",
+      totalQty: "الكمية الإجمالية",
+      selloutQty: "كمية المبيع",
+      submitOrder: "إرسال الطلب",
+      preview: "معاينة",
+      reset: "إعادة تعيين",
+      confirmSubmission: "تأكيد الإرسال",
+      confirmQuestion: "هل أنت متأكد أنك تريد إرسال هذا الطلب؟",
+      cancel: "إلغاء",
+      confirmSubmit: "تأكيد الإرسال",
+      orderPreview: "معاينة الطلب",
+      close: "إغلاق",
+      appLoaded: "تم تحميل التطبيق بنجاح",
+      validationError: "يرجى إكمال جميع الحقول المطلوبة",
+      validationTitle: "خطأ في التحقق",
+      noProducts: "يرجى إدخال كمية منتج واحدة على الأقل أو كمية المبيعات",
+      noProductsTitle: "لا توجد منتجات",
+      noProductsPreview: "لم يتم اختيار منتجات للمعاينة",
+      submitSuccess: "تم إرسال الطلب بنجاح!",
+      success: "نجاح",
+      submitFailed: "فشل الإرسال",
+      submissionError: "خطأ في الإرسال",
+      initError: "فشل في تهيئة التطبيق. يرجى تحديث الصفحة.",
+      initErrorTitle: "خطأ في التهيئة",
+      formReset: "تمت إعادة تعيين النموذج بنجاح",
+      resetConfirm: "هل أنت متأكد أنك تريد إعادة تعيين النموذج؟ ستفقد جميع البيانات.",
+      submitting: "جاري الإرسال...",
+      loadingData: "جاري تحميل بيانات المخزون...",
+      orderDetailsHeader: "تفاصيل الطلب",
+      weekLabel: "الأسبوع:",
+      channelLabel: "القناة:",
+      salesmanLabel: "مندوب المبيعات:",
+      customerLabel: "العميل:",
+      productCol: "المنتج",
+      quantityCol: "الكمية",
+      selloutCol: "المبيعات",
+      dataRestored: "تمت استعادة بيانات النموذج بنجاح",
+      restoreConfirm: "تم العثور على بيانات محفوظة للنموذج. هل ترغب في استعادتها؟",
+      loadingWarning: "يتم تحميل جداول Google ببطء. سيتم استخدام البيانات المخزنة إذا كانت متاحة.",
+      usingCachedData: "يتم استخدام البيانات المخزنة مؤقتًا",
+      loadingWarningTitle: "تحذير التحميل",
+      loadingError: "فشل في تحميل بيانات المنتج. يرجى تحديث الصفحة.",
+      loadingErrorTitle: "خطأ في التحميل",
+      failedProducts: "فشل تحميل المنتجات. يرجى تحديث الصفحة.",
+      retry: "إعادة المحاولة"
+    }
+  }
+};
+
+function updateTranslations() {
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    const key = el.getAttribute('data-i18n');
+    if (i18next.exists(key)) {
+      el.textContent = i18next.t(key);
+    }
+  });
+  document.documentElement.dir = i18next.language === 'ar' ? 'rtl' : 'ltr';
+  document.documentElement.lang = i18next.language;
+}
+
+i18next.init({
+  lng: 'en',
+  resources
+}, err => {
+  if (err) {
+    console.error('i18next init error:', err);
+  }
+  updateTranslations();
+});
+
+elements.languageSwitcher.addEventListener('change', e => {
+  i18next.changeLanguage(e.target.value, updateTranslations);
+});
 
 // Utility Functions
 const debounce = (func, delay) => {
@@ -203,7 +379,7 @@ function loadSavedData() {
       // Check if data is recent (within 24 hours)
       const hoursAgo = (Date.now() - data.timestamp) / (1000 * 60 * 60);
       if (hoursAgo < 24) {
-        if (confirm('Found saved form data. Would you like to restore it?')) {
+        if (confirm(i18next.t('restoreConfirm'))) {
           elements.weekSelect.value = data.week || '';
           elements.channelSelect.value = data.channel || '';
           elements.salesmanSelect.value = data.salesman || '';
@@ -212,7 +388,7 @@ function loadSavedData() {
           
           // Update UI
           updateProgress();
-          showToast('Form data restored successfully', 'success');
+          showToast(i18next.t('dataRestored'), 'success');
         }
       }
     }
@@ -275,8 +451,9 @@ async function loadDropdowns() {
     
     // Load channels
     const channels = [...new Set(data.map(r => r.Channel))].filter(Boolean);
-    elements.channelSelect.innerHTML = '<option value="">-- Select Channel --</option>' + 
+    elements.channelSelect.innerHTML = `<option value="" data-i18n="channelPlaceholder">${i18next.t('channelPlaceholder')}</option>` +
       channels.map(c => `<option value="${c}">${c}</option>`).join("");
+    updateTranslations();
     
     hideLoadingIndicator('channel');
     
@@ -290,15 +467,17 @@ async function loadDropdowns() {
         const salesmen = data.filter(r => r.Channel === selectedChannel).map(r => r["Salesman Name"]);
         const uniqueSalesmen = [...new Set(salesmen)].filter(Boolean);
         
-        elements.salesmanSelect.innerHTML = '<option value="">-- Select Salesman --</option>' + 
+        elements.salesmanSelect.innerHTML = `<option value="" data-i18n="salesmanPlaceholder">${i18next.t('salesmanPlaceholder')}</option>` +
           uniqueSalesmen.map(s => `<option value="${s}">${s}</option>`).join("");
-        elements.customerSelect.innerHTML = '<option value="">-- Select Customer --</option>';
+        elements.customerSelect.innerHTML = `<option value="" data-i18n="customerPlaceholder">${i18next.t('customerPlaceholder')}</option>`;
+        updateTranslations();
         
         hideLoadingIndicator('salesman');
         validateField('channel', selectedChannel);
       } else {
-        elements.salesmanSelect.innerHTML = '<option value="">-- Select Salesman --</option>';
-        elements.customerSelect.innerHTML = '<option value="">-- Select Customer --</option>';
+        elements.salesmanSelect.innerHTML = `<option value="" data-i18n="salesmanPlaceholder">${i18next.t('salesmanPlaceholder')}</option>`;
+        elements.customerSelect.innerHTML = `<option value="" data-i18n="customerPlaceholder">${i18next.t('customerPlaceholder')}</option>`;
+        updateTranslations();
       }
       
       updateProgress();
@@ -315,13 +494,15 @@ async function loadDropdowns() {
         const customers = data.filter(r => r["Salesman Name"] === selectedSalesman).map(r => r["Customer Name"]);
         const uniqueCustomers = [...new Set(customers)].filter(Boolean);
         
-        elements.customerSelect.innerHTML = '<option value="">-- Select Customer --</option>' + 
+        elements.customerSelect.innerHTML = `<option value="" data-i18n="customerPlaceholder">${i18next.t('customerPlaceholder')}</option>` +
           uniqueCustomers.map(c => `<option value="${c}">${c}</option>`).join("");
+        updateTranslations();
         
         hideLoadingIndicator('customer');
         validateField('salesman', selectedSalesman);
       } else {
-        elements.customerSelect.innerHTML = '<option value="">-- Select Customer --</option>';
+        elements.customerSelect.innerHTML = `<option value="" data-i18n="customerPlaceholder">${i18next.t('customerPlaceholder')}</option>`;
+        updateTranslations();
       }
       
       updateProgress();
@@ -359,7 +540,7 @@ async function loadDropdowns() {
     
   } catch (error) {
     console.error('Error loading dropdowns:', error);
-    showToast('Google Sheets loading slowly. Using cached data if available.', 'warning', 'Loading Warning');
+    showToast(i18next.t('loadingWarning'), 'warning', i18next.t('loadingWarningTitle'));
     hideLoadingIndicator('channel');
     
     // Try to use cached data from localStorage
@@ -368,9 +549,10 @@ async function loadDropdowns() {
       try {
         const data = JSON.parse(cachedData);
         const channels = [...new Set(data.map(r => r.Channel))].filter(Boolean);
-        elements.channelSelect.innerHTML = '<option value="">-- Select Channel --</option>' + 
+        elements.channelSelect.innerHTML = `<option value="" data-i18n="channelPlaceholder">${i18next.t('channelPlaceholder')}</option>` +
           channels.map(c => `<option value="${c}">${c}</option>`).join("");
-        showToast('Using cached data', 'info');
+        updateTranslations();
+        showToast(i18next.t('usingCachedData'), 'info');
       } catch (e) {
         console.error('Error parsing cached data:', e);
       }
@@ -451,14 +633,14 @@ async function loadProducts() {
     
   } catch (error) {
     console.error('Error loading products:', error);
-    showToast('Failed to load product data. Please refresh the page.', 'error', 'Loading Error');
+    showToast(i18next.t('loadingError'), 'error', i18next.t('loadingErrorTitle'));
     elements.productsContainer.innerHTML = `
       <div class="error-state">
         <i class="fas fa-exclamation-triangle"></i>
-        <p>Failed to load products. Please refresh the page.</p>
+        <p>${i18next.t('failedProducts')}</p>
         <button class="btn btn-primary" onclick="loadProducts()">
           <i class="fas fa-refresh"></i>
-          Retry
+          ${i18next.t('retry')}
         </button>
       </div>
     `;
@@ -625,34 +807,40 @@ function collapseAll() {
   });
 }
 
-function resetForm() {
-  if (confirm('Are you sure you want to reset the form? All data will be lost.')) {
-    // Reset form fields
-    elements.weekSelect.value = '';
-    elements.channelSelect.value = '';
-    elements.salesmanSelect.innerHTML = '<option value="">-- Select Salesman --</option>';
-    elements.customerSelect.innerHTML = '<option value="">-- Select Customer --</option>';
-    
-    // Reset product quantities
-    appState.productQuantities = {};
-    
-    // Reset product inputs
-    document.querySelectorAll('.product-input').forEach(input => {
-      input.value = '';
-    });
-    
-    // Remove visual states
-    document.querySelectorAll('.product.has-quantity').forEach(product => {
-      product.classList.remove('has-quantity');
-    });
-    
-    // Clear saved data
-    localStorage.removeItem('stockInTradeFormData');
-    
-    // Update UI
-    updateProgress();
-    showToast('Form reset successfully', 'success');
+function resetForm(confirmReset = true) {
+  if (confirmReset) {
+    const proceed = confirm(i18next.t('resetConfirm'));
+    if (!proceed) {
+      return;
+    }
   }
+
+  // Reset form fields
+  elements.weekSelect.value = '';
+  elements.channelSelect.value = '';
+  elements.salesmanSelect.innerHTML = `<option value="" data-i18n="salesmanPlaceholder">${i18next.t('salesmanPlaceholder')}</option>`;
+  elements.customerSelect.innerHTML = `<option value="" data-i18n="customerPlaceholder">${i18next.t('customerPlaceholder')}</option>`;
+  updateTranslations();
+
+  // Reset product quantities
+  appState.productQuantities = {};
+
+  // Reset product inputs
+  document.querySelectorAll('.product-input').forEach(input => {
+    input.value = '';
+  });
+
+  // Remove visual states
+  document.querySelectorAll('.product.has-quantity').forEach(product => {
+    product.classList.remove('has-quantity');
+  });
+
+  // Clear saved data
+  localStorage.removeItem('stockInTradeFormData');
+
+  // Update UI
+  updateProgress();
+  showToast(i18next.t('formReset'), 'success');
 }
 
 // Preview Functions
@@ -660,31 +848,31 @@ function previewOrder() {
   const orderData = collectOrderData();
   
   if (orderData.length === 0) {
-    showToast('No products selected for preview', 'warning');
+    showToast(i18next.t('noProductsPreview'), 'warning');
     return;
   }
   
   const previewContent = document.getElementById('previewContent');
   previewContent.innerHTML = `
     <div class="preview-header">
-      <h4>Order Details</h4>
+      <h4>${i18next.t('orderDetailsHeader')}</h4>
       <div class="preview-info">
-        <p><strong>Week:</strong> ${elements.weekSelect.value}</p>
-        <p><strong>Channel:</strong> ${elements.channelSelect.value}</p>
-        <p><strong>Salesman:</strong> ${elements.salesmanSelect.value}</p>
-        <p><strong>Customer:</strong> ${elements.customerSelect.value}</p>
+        <p><strong>${i18next.t('weekLabel')}</strong> ${elements.weekSelect.value}</p>
+        <p><strong>${i18next.t('channelLabel')}</strong> ${elements.channelSelect.value}</p>
+        <p><strong>${i18next.t('salesmanLabel')}</strong> ${elements.salesmanSelect.value}</p>
+        <p><strong>${i18next.t('customerLabel')}</strong> ${elements.customerSelect.value}</p>
       </div>
     </div>
-    
+
     <div class="preview-products">
-      <h4>Products (${orderData.length})</h4>
+      <h4>${i18next.t('products')} (${orderData.length})</h4>
       <div class="preview-table">
         <table>
           <thead>
             <tr>
-              <th>Product</th>
-              <th>Quantity</th>
-              <th>Sellout</th>
+              <th>${i18next.t('productCol')}</th>
+              <th>${i18next.t('quantityCol')}</th>
+              <th>${i18next.t('selloutCol')}</th>
             </tr>
           </thead>
           <tbody>
@@ -745,29 +933,29 @@ function collectOrderData() {
 
 function submitForm() {
   if (!validateForm()) {
-    showToast('Please complete all required fields', 'error', 'Validation Error');
+    showToast(i18next.t('validationError'), 'error', i18next.t('validationTitle'));
     return;
   }
   
   const orderData = collectOrderData();
   
   if (orderData.length === 0) {
-    showToast('Please enter at least one product quantity or sellout quantity', 'warning', 'No Products');
+    showToast(i18next.t('noProducts'), 'warning', i18next.t('noProductsTitle'));
     return;
   }
   
   // Show confirmation modal
   const modalSummary = document.getElementById('modalSummary');
   modalSummary.innerHTML = `
-    <p><strong>Order Summary:</strong></p>
+    <p><strong>${i18next.t('orderSummary')}:</strong></p>
     <ul>
-      <li>Week: ${elements.weekSelect.value}</li>
-      <li>Channel: ${elements.channelSelect.value}</li>
-      <li>Salesman: ${elements.salesmanSelect.value}</li>
-      <li>Customer: ${elements.customerSelect.value}</li>
-      <li>Products: ${orderData.length} items</li>
-      <li>Total Quantity: ${orderData.reduce((sum, item) => sum + item.qty, 0)}</li>
-      <li>Total Sellout: ${orderData.reduce((sum, item) => sum + item.sellout, 0)}</li>
+      <li>${i18next.t('week')}: ${elements.weekSelect.value}</li>
+      <li>${i18next.t('channel')}: ${elements.channelSelect.value}</li>
+      <li>${i18next.t('salesman')}: ${elements.salesmanSelect.value}</li>
+      <li>${i18next.t('customer')}: ${elements.customerSelect.value}</li>
+      <li>${i18next.t('productsStat')}: ${orderData.length}</li>
+      <li>${i18next.t('totalQty')}: ${orderData.reduce((sum, item) => sum + item.qty, 0)}</li>
+      <li>${i18next.t('selloutQty')}: ${orderData.reduce((sum, item) => sum + item.sellout, 0)}</li>
     </ul>
   `;
   
@@ -779,38 +967,41 @@ async function confirmSubmit() {
     // Close modal and show loading
     closeModal();
     elements.submitBtn.disabled = true;
-    elements.submitBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Submitting...';
+    elements.submitBtn.innerHTML = `<i class="fas fa-spinner fa-spin"></i> ${i18next.t('submitting')}`;
     
     const orderData = collectOrderData();
-    const formData = new FormData();
-    formData.append("data", JSON.stringify(orderData));
-    
+
     const response = await fetch("https://script.google.com/macros/s/AKfycbwTTKahHaWxeODCJ2SmXMXxpRJfh9zeWHJjuEgLc4ZkMovWk-VZ3xiszTEUBFRlD1RZMg/exec", {
       method: "POST",
-      body: formData
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(orderData)
     });
-    
-    const result = await response.json();
-    
-    if (result.status === "success") {
-      showToast('Order submitted successfully!', 'success', 'Success');
-      
-      // Clear saved data
-      localStorage.removeItem('stockInTradeFormData');
-      
-resetForm(); // ✅ Instantly reset the form after success
-      
-    } else {
-      throw new Error(result.message || 'Submission failed');
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
     }
+
+    const result = await response.json();
+    if (result.status !== "success") {
+      throw new Error(result.message || "Unknown error");
+    }
+
+    showToast(i18next.t('submitSuccess'), 'success', i18next.t('success'));
+
+    // Clear saved data
+    localStorage.removeItem('stockInTradeFormData');
+
+    resetForm(false); // Instantly reset the form after success without confirmation
     
   } catch (error) {
     console.error('Submission error:', error);
-    showToast(`Submission failed: ${error.message}`, 'error', 'Submission Error');
+    showToast(`${i18next.t('submitFailed')}: ${error.message}`, 'error', i18next.t('submissionError'));
     
   } finally {
     elements.submitBtn.disabled = false;
-    elements.submitBtn.innerHTML = '<i class="fas fa-paper-plane"></i> Submit Order';
+    elements.submitBtn.innerHTML = `<i class="fas fa-paper-plane"></i> <span data-i18n="submitOrder">${i18next.t('submitOrder')}</span>`;
   }
 }
 
@@ -860,7 +1051,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Initialize progress
     updateProgress();
     
-    showToast('Application loaded successfully', 'success');
+    showToast(i18next.t('appLoaded'), 'success');
     
     // Add manual test functionality
     window.testFormState = () => {
@@ -876,7 +1067,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     
   } catch (error) {
     console.error('Initialization error:', error);
-    showToast('Failed to initialize application. Please refresh the page.', 'error', 'Initialization Error');
+    showToast(i18next.t('initError'), 'error', i18next.t('initErrorTitle'));
     elements.loadingOverlay.classList.add('hidden');
   }
 });


### PR DESCRIPTION
## Summary
- Replace Google Translate widget with an i18next-powered language selector for English and Arabic
- Add comprehensive translation resources and dynamic language switching
- Harden form submission by verifying the Apps Script response and adding CORS headers

## Testing
- `node --check script.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dd40b45e48328bb550e1a5d1d5144