### PR TITLE
Fix week selection persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
               </label>
               <div class="select-wrapper">
                 <select id="week" class="form-select" required aria-describedby="week-error">
-                  <option value="" data-i18n="weekPlaceholder">-- Select Week --</option>
+                  <option value="" data-i18n="weekPlaceholder" selected>-- Select Week --</option>
                   <option value="Week 1" data-i18n="week1">Week 1</option>
                   <option value="Week 2" data-i18n="week2">Week 2</option>
                   <option value="Week 3" data-i18n="week3">Week 3</option>

--- a/script.js
+++ b/script.js
@@ -1031,7 +1031,16 @@ document.addEventListener('DOMContentLoaded', async () => {
   try {
     // Hide loading overlay immediately - let app work without waiting for data
     elements.loadingOverlay.classList.add('hidden');
-    
+
+    // Ensure a fresh form state on initial load so previously selected
+    // values aren't persisted by the browser or saved data. This clears
+    // any pre-filled values before optionally restoring saved data.
+    elements.weekSelect.value = '';
+    elements.channelSelect.value = '';
+    elements.salesmanSelect.innerHTML = `<option value="" data-i18n="salesmanPlaceholder">${i18next.t('salesmanPlaceholder')}</option>`;
+    elements.customerSelect.innerHTML = `<option value="" data-i18n="customerPlaceholder">${i18next.t('customerPlaceholder')}</option>`;
+    updateProgress();
+
     // Load saved data
     loadSavedData();
     


### PR DESCRIPTION
## Summary
- Ensure week, channel, salesman and customer fields reset on page load
- Mark placeholder week option as default selected

## Testing
- `node --check script.js`
- `npx htmlhint index.html` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_688dde1593b083289d0088f66d089084