### PR TITLE
Handle CORS for Google Apps Script submissions

### DIFF
--- a/attached_assets/script (4)_1752227139343.js
+++ b/attached_assets/script (4)_1752227139343.js
@@ -2,6 +2,10 @@ const channelSelect = document.getElementById("channel");
 const salesmanSelect = document.getElementById("salesman");
 const customerSelect = document.getElementById("customer");
 
+const GOOGLE_SCRIPT_URL = 'https://script.google.com/macros/s/AKfycbwTTKahHaWxeODCJ2SmXMXxpRJfh9zeWHJjuEgLc4ZkMovWk-VZ3xiszTEUBFRlD1RZMg/exec';
+const CORS_PROXY = 'https://corsproxy.io/?';
+const PROXIED_SCRIPT_URL = `${CORS_PROXY}${encodeURIComponent(GOOGLE_SCRIPT_URL)}`;
+
 function loadDropdowns() {
   fetch("https://docs.google.com/spreadsheets/d/e/2PACX-1vREXfVVJ4zYuYx40MkvrBI8aH2OYr81ZlF2b_owlbT1o_RhXC44_egEmLCOiLrD5iVPo-CAuYRrVqIC/pub?gid=1284241246&single=true&output=csv")
     .then(res => res.text())
@@ -135,7 +139,7 @@ function submitForm() {
   const formData = new FormData();
   formData.append("data", JSON.stringify(entries));
 
-  fetch("https://script.google.com/macros/s/AKfycbwTTKahHaWxeODCJ2SmXMXxpRJfh9zeWHJjuEgLc4ZkMovWk-VZ3xiszTEUBFRlD1RZMg/exec", {
+  fetch(PROXIED_SCRIPT_URL, {
     method: "POST",
     body: formData
   })

--- a/script.js
+++ b/script.js
@@ -181,6 +181,11 @@ const resources = {
   }
 };
 
+// Google Apps Script endpoint and CORS proxy
+const GOOGLE_SCRIPT_URL = 'https://script.google.com/macros/s/AKfycbwTTKahHaWxeODCJ2SmXMXxpRJfh9zeWHJjuEgLc4ZkMovWk-VZ3xiszTEUBFRlD1RZMg/exec';
+const CORS_PROXY = 'https://corsproxy.io/?';
+const PROXIED_SCRIPT_URL = `${CORS_PROXY}${encodeURIComponent(GOOGLE_SCRIPT_URL)}`;
+
 function updateTranslations() {
   document.querySelectorAll('[data-i18n]').forEach(el => {
     const key = el.getAttribute('data-i18n');
@@ -971,7 +976,7 @@ async function confirmSubmit() {
     
     const orderData = collectOrderData();
 
-    const response = await fetch("https://script.google.com/macros/s/AKfycbwTTKahHaWxeODCJ2SmXMXxpRJfh9zeWHJjuEgLc4ZkMovWk-VZ3xiszTEUBFRlD1RZMg/exec", {
+    const response = await fetch(PROXIED_SCRIPT_URL, {
       method: "POST",
       headers: {
         "Content-Type": "application/json"


### PR DESCRIPTION
## Summary
- route form submissions through a CORS proxy to bypass browser restrictions when posting to Google Apps Script
- update auxiliary script to use the same proxied endpoint

## Testing
- `curl -X POST -H "Content-Type: application/json" -d '{"test":true}' "https://corsproxy.io/?https://script.google.com/macros/s/AKfycbwTTKahHaWxeODCJ2SmXMXxpRJfh9zeWHJjuEgLc4ZkMovWk-VZ3xiszTEUBFRlD1RZMg/exec"` *(Method forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688def7cccf08328a602a82661ee8dab