### PR TITLE
Handle non-JSON responses during submission

### DIFF
--- a/script.js
+++ b/script.js
@@ -988,7 +988,16 @@ async function confirmSubmit() {
       throw new Error(`HTTP ${response.status}`);
     }
 
-    const result = await response.json();
+    const contentType = response.headers.get("content-type") || "";
+    let result;
+    if (contentType.includes("application/json")) {
+      result = await response.json();
+    } else {
+      const text = await response.text();
+      console.error("Unexpected response: ", text);
+      throw new Error("Invalid response from server");
+    }
+
     if (result.status !== "success") {
       throw new Error(result.message || "Unknown error");
     }


### PR DESCRIPTION
## Summary
- Guard against non-JSON responses when submitting the form
- Log unexpected responses and show a clearer error message

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688df349803c8328a1204bfd4c4b4904