### PR TITLE
Handle text responses as JSON

### DIFF
--- a/script.js
+++ b/script.js
@@ -994,8 +994,12 @@ async function confirmSubmit() {
       result = await response.json();
     } else {
       const text = await response.text();
-      console.error("Unexpected response: ", text);
-      throw new Error("Invalid response from server");
+      try {
+        result = JSON.parse(text);
+      } catch (e) {
+        console.error("Unexpected response: ", text);
+        throw new Error("Invalid response from server");
+      }
     }
 
     if (result.status !== "success") {


### PR DESCRIPTION
## Summary
- Parse server replies even when they are plain text to avoid false submission errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e49f83848832887fa586815810e02