### PR TITLE
fix: remove unsupported header setting

### DIFF
--- a/appsScript.gs
+++ b/appsScript.gs
@@ -25,13 +25,13 @@ function doPost(e) {
 
       return ContentService
         .createTextOutput(JSON.stringify({ status: "success" }))
-        .setMimeType(ContentService.MimeType.JSON)
-        .setHeader("Access-Control-Allow-Origin", "*");
+        .setMimeType(ContentService.MimeType.JSON);
     } catch (err) {
       return ContentService
-        .createTextOutput(JSON.stringify({ status: "error", message: err.message }))
-        .setMimeType(ContentService.MimeType.JSON)
-        .setHeader("Access-Control-Allow-Origin", "*");
+        .createTextOutput(
+          JSON.stringify({ status: "error", message: err.message })
+        )
+        .setMimeType(ContentService.MimeType.JSON);
     }
   }
 


### PR DESCRIPTION
## Summary
- avoid unsupported `setHeader` on Apps Script responses causing TypeError

## Testing
- `node --check script.js`
- `cp appsScript.gs /tmp/appsScript.js && node --check /tmp/appsScript.js`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e4c52bfac8328b5bf6788898c8edb